### PR TITLE
Return path

### DIFF
--- a/include/RestEndpoint.hpp
+++ b/include/RestEndpoint.hpp
@@ -30,7 +30,7 @@
 namespace dunedaq {
 namespace restcmd {
 
-typedef std::map<std::string, nlohmann::json> cmdmeta_t;
+typedef std::map<std::string, std::string> cmdmeta_t;
 
 class RestEndpoint {
 public: 
@@ -51,7 +51,7 @@ public:
   void shutdown();
 
   // Client handler
-  void handleResponseCommand();
+  void handleResponseCommand(cmdmeta_t& meta);
   
 private:
   void createRouting();

--- a/include/RestEndpoint.hpp
+++ b/include/RestEndpoint.hpp
@@ -30,12 +30,13 @@
 namespace dunedaq {
 namespace restcmd {
 
-typedef std::map<std::string, std::string> cmdmeta_t;
+typedef nlohmann::json cmdobj_t;
+typedef nlohmann::json cmdmeta_t;
 
 class RestEndpoint {
 public: 
   explicit RestEndpoint(const std::string& /*uri*/, int port,
-                        std::function<void(cmdmeta_t)> callback) noexcept 
+                        std::function<void(const cmdobj_t&, cmdmeta_t)> callback) noexcept 
     : port_{ static_cast<uint16_t>(port) }
     , address_{ Pistache::Ipv4::any(), port_ }
     , http_endpoint_{ std::make_shared<Pistache::Http::Endpoint>( address_ ) }
@@ -51,7 +52,7 @@ public:
   void shutdown();
 
   // Client handler
-  void handleResponseCommand(cmdmeta_t& meta);
+  void handleResponseCommand(const cmdobj_t& cmd, cmdmeta_t& meta);
   
 private:
   void createRouting();
@@ -76,7 +77,7 @@ private:
   std::vector<Pistache::Async::Promise<Pistache::Http::Response>> http_client_responses_;
 
   // Function to call with received POST bodies
-  std::function<void(cmdmeta_t)> command_callback_;
+  std::function<void(const cmdobj_t&, cmdmeta_t)> command_callback_;
 
   // Background server thread
   std::thread server_thread_;

--- a/include/RestEndpoint.hpp
+++ b/include/RestEndpoint.hpp
@@ -30,10 +30,12 @@
 namespace dunedaq {
 namespace restcmd {
 
+typedef std::map<std::string, nlohmann::json> cmdmeta_t;
+
 class RestEndpoint {
 public: 
   explicit RestEndpoint(const std::string& /*uri*/, int port,
-                        std::function<void(const nlohmann::json&)> callback) noexcept 
+                        std::function<void(cmdmeta_t)> callback) noexcept 
     : port_{ static_cast<uint16_t>(port) }
     , address_{ Pistache::Ipv4::any(), port_ }
     , http_endpoint_{ std::make_shared<Pistache::Http::Endpoint>( address_ ) }
@@ -48,6 +50,9 @@ public:
   void stop();
   void shutdown();
 
+  // Client handler
+  void handleResponseCommand();
+  
 private:
   void createRouting();
   void createDescription();
@@ -55,8 +60,7 @@ private:
 
   // Route handler
   void handleRouteCommand(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
-  // Client handler
-  void handleResponseCommand();
+
 
   // REST
   Pistache::Port port_;
@@ -72,7 +76,7 @@ private:
   std::vector<Pistache::Async::Promise<Pistache::Http::Response>> http_client_responses_;
 
   // Function to call with received POST bodies
-  std::function<void(const nlohmann::json&)> command_callback_;
+  std::function<void(cmdmeta_t)> command_callback_;
 
   // Background server thread
   std::thread server_thread_;

--- a/include/RestEndpoint.hpp
+++ b/include/RestEndpoint.hpp
@@ -18,6 +18,7 @@
 #include <pistache/description.h>
 #include <pistache/router.h>
 #include <pistache/endpoint.h>
+#include <pistache/client.h>
 #include <pistache/mime.h>
 
 #include <thread>
@@ -32,13 +33,14 @@ namespace restcmd {
 class RestEndpoint {
 public: 
   explicit RestEndpoint(const std::string& /*uri*/, int port,
-                        std::function<void(const nlohmann::json&)> functor) noexcept 
+                        std::function<void(const nlohmann::json&)> callback) noexcept 
     : port_{ static_cast<uint16_t>(port) }
     , address_{ Pistache::Ipv4::any(), port_ }
     , http_endpoint_{ std::make_shared<Pistache::Http::Endpoint>( address_ ) }
     , description_{ "DUNE DAQ cmdlib API", "0.1" }
     , accepted_mime_{ MIME(Application, Json) }
-    , command_callback_{ functor }
+    , http_client_{ std::make_shared<Pistache::Http::Client>() }
+    , command_callback_{ callback }
   { }
 
   void init(size_t threads);
@@ -51,8 +53,10 @@ private:
   void createDescription();
   void serveTask(); 
 
-  // Routes
+  // Route handler
   void handleRouteCommand(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
+  // Client handler
+  void handleResponseCommand();
 
   // REST
   Pistache::Port port_;
@@ -61,6 +65,11 @@ private:
   Pistache::Rest::Description description_;
   Pistache::Rest::Router router_;
   Pistache::Http::Mime::MediaType accepted_mime_;
+
+  // CLIENT
+  std::shared_ptr<Pistache::Http::Client> http_client_;
+  Pistache::Http::Client::Options http_client_options_;
+  std::vector<Pistache::Async::Promise<Pistache::Http::Response>> http_client_responses_;
 
   // Function to call with received POST bodies
   std::function<void(const nlohmann::json&)> command_callback_;

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -64,7 +64,7 @@ public:
       }
 
       try { // to setup backend
-        command_executor_ = std::bind(&inherited::execute_command, this, std::placeholders::_1);
+        command_executor_ = std::bind(&inherited::execute_command, this, std::placeholders::_1, std::placeholders::_2);
         rest_endpoint_= std::make_unique<dunedaq::restcmd::RestEndpoint>(hostname, port, command_executor_);
         rest_endpoint_->init(1); // 1 thread
         ERS_INFO("Endpoint open on: " << epname << " host:" << hostname << " port:" << portstr);
@@ -96,15 +96,15 @@ protected:
     typedef CommandFacility inherited;
     
     // Implementation of completionHandler interface
-    void completion_callback(cmdmeta_t& meta) {
-      rest_endpoint_->handleResponseCommand(meta);
+    void completion_callback(const cmdobj_t& cmd, cmdmeta_t& meta) {
+      rest_endpoint_->handleResponseCommand(cmd, meta);
     }
 
 private:
     // Manager, HTTP REST Endpoint and backend resources
     mutable std::unique_ptr<RestEndpoint> rest_endpoint_;
 
-    typedef std::function<void(cmdmeta_t)> RequestCallback;
+    typedef std::function<void(const cmdobj_t&, cmdmeta_t)> RequestCallback;
     RequestCallback command_executor_;
 
 };

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -97,10 +97,10 @@ protected:
     
     // Implementation of completionHandler interface
     void completion_callback(cmdmeta_t& meta) {
-      ERS_INFO("Completion result: " << meta.at("result"));
-      ERS_INFO("Completion ansport: " << meta.at("answer-port"));
-      ERS_INFO("Completion command: " << meta.at("command"));
-      rest_endpoint_->handleResponseCommand();
+      // ERS_INFO("Completion result: " << meta.at("result"));
+      // ERS_INFO("Completion ansport: " << meta.at("answer-port"));
+      // ERS_INFO("Completion command: " << meta.at("command"));
+      rest_endpoint_->handleResponseCommand(meta);
     }
 
 private:

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -107,7 +107,7 @@ private:
     // Manager, HTTP REST Endpoint and backend resources
     mutable std::unique_ptr<RestEndpoint> rest_endpoint_;
 
-    typedef std::function<void(cmdobj_t)> RequestCallback;
+    typedef std::function<void(cmdmeta_t)> RequestCallback;
     RequestCallback command_executor_;
 
 };

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -97,9 +97,6 @@ protected:
     
     // Implementation of completionHandler interface
     void completion_callback(cmdmeta_t& meta) {
-      // ERS_INFO("Completion result: " << meta.at("result"));
-      // ERS_INFO("Completion ansport: " << meta.at("answer-port"));
-      // ERS_INFO("Completion command: " << meta.at("command"));
       rest_endpoint_->handleResponseCommand(meta);
     }
 

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -64,7 +64,7 @@ public:
       }
 
       try { // to setup backend
-        command_executor_ = std::bind(&inherited::executeCommand, this, std::placeholders::_1);
+        command_executor_ = std::bind(&inherited::execute_command, this, std::placeholders::_1);
         rest_endpoint_= std::make_unique<dunedaq::restcmd::RestEndpoint>(hostname, port, command_executor_);
         rest_endpoint_->init(1); // 1 thread
         ERS_INFO("Endpoint open on: " << epname << " host:" << hostname << " port:" << portstr);
@@ -96,7 +96,7 @@ protected:
     typedef CommandFacility inherited;
     
     // Implementation of completionHandler interface
-    void completionCallback(cmdmeta_t& meta) {
+    void completion_callback(cmdmeta_t& meta) {
       ERS_INFO("Completion result: " << meta.at("result"));
       ERS_INFO("Completion ansport: " << meta.at("answer-port"));
       ERS_INFO("Completion command: " << meta.at("command"));

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -64,7 +64,7 @@ public:
       }
 
       try { // to setup backend
-        command_executor_ = std::bind(&inherited::execute_command, this, std::placeholders::_1);
+        command_executor_ = std::bind(&inherited::executeCommand, this, std::placeholders::_1);
         rest_endpoint_= std::make_unique<dunedaq::restcmd::RestEndpoint>(hostname, port, command_executor_);
         rest_endpoint_->init(1); // 1 thread
         ERS_INFO("Endpoint open on: " << epname << " host:" << hostname << " port:" << portstr);
@@ -94,17 +94,20 @@ public:
 
 protected:
     typedef CommandFacility inherited;
-
+    
     // Implementation of completionHandler interface
-    void completion_callback(const std::string& result) {
-      ERS_INFO("Need to add HTTP reply with result: " << result);
+    void completionCallback(cmdmeta_t& meta) {
+      ERS_INFO("Completion result: " << meta.at("result"));
+      ERS_INFO("Completion ansport: " << meta.at("answer-port"));
+      ERS_INFO("Completion command: " << meta.at("command"));
+      rest_endpoint_->handleResponseCommand();
     }
 
 private:
     // Manager, HTTP REST Endpoint and backend resources
     mutable std::unique_ptr<RestEndpoint> rest_endpoint_;
 
-    typedef std::function<void(const cmdobj_t&)> RequestCallback;
+    typedef std::function<void(cmdobj_t)> RequestCallback;
     RequestCallback command_executor_;
 
 };

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,3 +15,9 @@ One can also specify a wait time between sending commands.
 There is also an interactive mode. This requires typing the next command's ID from the set of commands that are available in the file:
 
     send-restcmd.py --file ../test/fdpc-commands.json --interactive
+
+## Receiving command return
+
+    recv-restcmd.py
+
+starts a Flask server exposing a POST `/response` route on a configurable port (default 12333).

--- a/scripts/recv-restcmd.py
+++ b/scripts/recv-restcmd.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+from flask import Flask, request
+from multiprocessing import Process
+
+parser = argparse.ArgumentParser(description='')
+parser.add_argument('-a', '--answer-port', type=int, default=12333, help='listening port for command return')
+
+args = parser.parse_args()
+
+app = Flask(__name__)
+
+@app.route('/response', methods = ['POST'])
+def index():
+  json = request.get_json(force=True)
+  print("Result: ", json["result"])
+  print("of command: ", json["command"])
+  return 'Response received'
+
+if __name__ == "__main__":
+  app.run(port=args.answer_port)
+

--- a/scripts/send-restcmd.py
+++ b/scripts/send-restcmd.py
@@ -24,7 +24,7 @@ args = parser.parse_args()
 
 app = Flask(__name__)
 
-@app.route('/', methods = ['POST'])
+@app.route('/response', methods = ['POST'])
 def index():
   json = request.get_json(force=True)
   print("Result: ", json["result"])

--- a/scripts/send-restcmd.py
+++ b/scripts/send-restcmd.py
@@ -6,9 +6,6 @@ import json
 import time
 import sys
 
-from flask import Flask, request
-from multiprocessing import Process
-
 parser = argparse.ArgumentParser(description='POST command object from file to commanded endpoint.')
 parser.add_argument('--host', type=str, default='localhost', help='target host/endpoint')
 parser.add_argument('-p', '--port', type=int, default=12345, help='target port')
@@ -21,22 +18,6 @@ parser.add_argument('--non-interactive', dest='interactive', action='store_false
 parser.set_defaults(interactive=False)
 
 args = parser.parse_args()
-
-app = Flask(__name__)
-
-@app.route('/response', methods = ['POST'])
-def index():
-  json = request.get_json(force=True)
-  print("Result: ", json["result"])
-  print("of command: ", json["command"])
-  return 'Response received'
-
-def FlaskApp():
-  app.run(port=args.answer_port)
-
-if __name__ == "__main__":
-  flask_server = Process(target=FlaskApp)
-  flask_server.start()
 
 url = 'http://'+args.host+':'+str(args.port)+'/'+args.route
 print('Target url: ' + url)
@@ -91,9 +72,5 @@ elif isinstance(cmdstr, list):
       except EOFError as e:
         break
 
-print("Wait for response...")
-time.sleep(0.5)
-print('Exiting...')
-flask_server.terminate()
-flask_server.join()
 
+print('Exiting...')

--- a/scripts/send-restcmd.py
+++ b/scripts/send-restcmd.py
@@ -72,5 +72,4 @@ elif isinstance(cmdstr, list):
       except EOFError as e:
         break
 
-
 print('Exiting...')

--- a/scripts/send-restcmd.py
+++ b/scripts/send-restcmd.py
@@ -21,7 +21,7 @@ args = parser.parse_args()
 
 url = 'http://'+args.host+':'+str(args.port)+'/'+args.route
 print('Target url: ' + url)
-headers = {'content-type': 'application/json', 'x-answer-port': bytes(args.answer_port)}
+headers = {'content-type': 'application/json', 'X-Answer-Port': str(args.answer_port)}
 
 cmdstr = None
 try:

--- a/scripts/send-restcmd.py
+++ b/scripts/send-restcmd.py
@@ -6,6 +6,9 @@ import json
 import time
 import sys
 
+from flask import Flask, request
+import threading
+
 parser = argparse.ArgumentParser(description='POST command object from file to commanded endpoint.')
 parser.add_argument('--host', type=str, default='localhost', help='target host/endpoint')
 parser.add_argument('-p', '--port', type=int, default=12345, help='target port')
@@ -18,6 +21,21 @@ parser.add_argument('--non-interactive', dest='interactive', action='store_false
 parser.set_defaults(interactive=False)
 
 args = parser.parse_args()
+
+app = Flask(__name__)
+
+@app.route('/', methods = ['POST'])
+def index():
+  json = request.get_json(force=True)
+  print("Result: ", json["result"])
+  print("of the command: ", json["command"])
+  return 'Response received'
+
+def FlaskApp():
+  app.run(port=args.answer_port)
+
+if __name__ == "__main__":
+  threading.Thread(target=FlaskApp).start()
 
 url = 'http://'+args.host+':'+str(args.port)+'/'+args.route
 print('Target url: ' + url)

--- a/scripts/send-restcmd.py
+++ b/scripts/send-restcmd.py
@@ -7,7 +7,7 @@ import time
 import sys
 
 from flask import Flask, request
-import threading
+from multiprocessing import Process
 
 parser = argparse.ArgumentParser(description='POST command object from file to commanded endpoint.')
 parser.add_argument('--host', type=str, default='localhost', help='target host/endpoint')
@@ -28,14 +28,15 @@ app = Flask(__name__)
 def index():
   json = request.get_json(force=True)
   print("Result: ", json["result"])
-  print("of the command: ", json["command"])
+  print("of command: ", json["command"])
   return 'Response received'
 
 def FlaskApp():
   app.run(port=args.answer_port)
 
 if __name__ == "__main__":
-  threading.Thread(target=FlaskApp).start()
+  flask_server = Process(target=FlaskApp)
+  flask_server.start()
 
 url = 'http://'+args.host+':'+str(args.port)+'/'+args.route
 print('Target url: ' + url)
@@ -90,4 +91,9 @@ elif isinstance(cmdstr, list):
       except EOFError as e:
         break
 
+print("Wait for response...")
+time.sleep(0.5)
 print('Exiting...')
+flask_server.terminate()
+flask_server.join()
+

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -7,7 +7,7 @@
  */
 #include "RestEndpoint.hpp"
 
-#include <ers/Issue.h>
+#include <ers/ers.h>
 
 #include <chrono>
 #include <future>
@@ -82,10 +82,10 @@ void RestEndpoint::handleRouteCommand(const Rest::Request& request, Http::Respon
   if ( ct->mime() != accepted_mime_ ) {
     auto res = response.send(Http::Code::Not_Acceptable, "Not a JSON command!\n");
   } else {
-    std::ostringstream hdrsstr;
-    for (const auto&[hk, rh] : headers.rawList()) {
-      hdrsstr << hk << ": " << rh.value() << '\n';
-    }
+    // std::ostringstream hdrsstr;
+    // for (const auto&[hk, rh] : headers.rawList()) {
+    //   hdrsstr << hk << ": " << rh.value() << '\n';
+    // }
     // std::cout << "From: "<< addr.host() << '\n';
     // std::cout << hdrsstr.str() << '\n';
 
@@ -107,7 +107,7 @@ void RestEndpoint::handleResponseCommand(cmdmeta_t & meta)
   auto response = http_client_->post(addrstr.str()).body(nlohmann::json(meta).dump()).send();
   response.then(
     [&](Http::Response response) {
-      std::cout << "Response code = " << response.code() << std::endl;
+      ERS_INFO("Response code = " << response.code());
       // auto body = response.body();
       // if (!body.empty())
         // std::cout << "Response body = " << body << std::endl;

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -25,7 +25,7 @@ void RestEndpoint::init(size_t threads)
     .maxResponseSize(1048576) // 1MB 
     .flags(Pistache::Tcp::Options::ReuseAddr)
     .flags(Pistache::Tcp::Options::ReusePort);
-    
+
   http_endpoint_->init(opts);
   createRouting();
   http_client_options_ = Http::Client::options().threads(static_cast<int>(threads));
@@ -102,15 +102,15 @@ void RestEndpoint::handleResponseCommand(cmdmeta_t & meta)
 {
   std::ostringstream addrstr;
   addrstr << meta["answer-host"] << ":" << meta["answer-port"];
-  //std::cout << addrstr.str() << std::endl;
-  auto response = http_client_->post(addrstr.str()).body(meta["result"]).send();
+  meta.erase("answer-host");
+  meta.erase("answer-port");
+  auto response = http_client_->post(addrstr.str()).body(nlohmann::json(meta).dump()).send();
   response.then(
     [&](Http::Response response) {
-      // ++completed_requests_;
       std::cout << "Response code = " << response.code() << std::endl;
-      auto body = response.body();
-      if (!body.empty())
-        std::cout << "Response body = " << body << std::endl;
+      // auto body = response.body();
+      // if (!body.empty())
+        // std::cout << "Response body = " << body << std::endl;
     },
     [&](std::exception_ptr exc) {
       // handle response failure

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -25,6 +25,7 @@ void RestEndpoint::init(size_t threads)
     .maxResponseSize(1048576) // 1MB 
     .flags(Pistache::Tcp::Options::ReuseAddr)
     .flags(Pistache::Tcp::Options::ReusePort);
+    
   http_endpoint_->init(opts);
   createRouting();
   http_client_options_ = Http::Client::options().threads(static_cast<int>(threads));

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -93,7 +93,7 @@ void RestEndpoint::handleRouteCommand(const Rest::Request& request, Http::Respon
     cmdmeta_t meta;
     meta["answer-port"] = ansport.value();
     meta["answer-host"] = addr.host();
-    command_callback_(nlohmann::json(request.body()), meta); // RS: FIXME parse errors
+    command_callback_(nlohmann::json::parse(request.body()), meta); // RS: FIXME parse errors
     auto res = response.send(Http::Code::Accepted, "Command received\n");
   }
 }

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -7,9 +7,12 @@
  */
 #include "RestEndpoint.hpp"
 
+#include <ers/Issue.h>
+
 #include <chrono>
 #include <future>
 #include <utility>
+#include <sstream>
 
 using namespace dunedaq::restcmd;
 using namespace Pistache;
@@ -22,9 +25,10 @@ void RestEndpoint::init(size_t threads)
     .maxResponseSize(1048576) // 1MB 
     .flags(Pistache::Tcp::Options::ReuseAddr)
     .flags(Pistache::Tcp::Options::ReusePort);
-    
   http_endpoint_->init(opts);
   createRouting();
+  http_client_options_ = Http::Client::options().threads(static_cast<int>(threads));
+  http_client_->init(http_client_options_);
 }
 
 void RestEndpoint::start() 
@@ -42,6 +46,7 @@ void RestEndpoint::shutdown()
 {
   http_endpoint_->shutdown();
   server_thread_.join();
+  http_client_->shutdown();
 }
 
 void RestEndpoint::createRouting()
@@ -57,16 +62,59 @@ inline void extendHeader(Http::Header::Collection& headers)
   headers.add<Http::Header::ContentType>(MIME(Text, Plain));
 }
 
+inline 
+std::string 
+getClientAddress(const Pistache::Rest::Request &request) {
+  const auto xff = request.headers().tryGetRaw("X-Forwarded-For");
+  if (!xff.isEmpty()) {
+    //TODO: Strip of after first comma (to handle chained proxies).
+    return xff.get().value();
+  }
+  return request.address().host();
+}
+
 void RestEndpoint::handleRouteCommand(const Rest::Request& request, Http::ResponseWriter response)
 {
-  //auto addr = request.address();
+  auto addr = request.address();
   auto headers = request.headers();
   auto ct = headers.get<Http::Header::ContentType>(); 
   if ( ct->mime() != accepted_mime_ ) {
-    auto res = response.send(Http::Code::Not_Acceptable, "Not a JSON command\n");
+    auto res = response.send(Http::Code::Not_Acceptable, "Not a JSON command!\n");
   } else {
-    //auto ansport = headers.getRaw("x-answer-port"); // RS: FIXME reply using headers
+    std::ostringstream hdrsstr;
+    for (const auto&[hk, rh] : headers.rawList()) {
+      hdrsstr << hk << ": " << rh.value() << '\n';
+    }
+    std::cout << "From: "<< addr.host() << '\n';
+    std::cout << hdrsstr.str() << '\n';
+    //ERS_DEBUG(2, hdrsstr.str()); // what do I need to include for ERS_DEBUG?
+
+    auto ansport = headers.getRaw("X-Answer-Port"); // RS: FIXME reply using headers
     command_callback_(nlohmann::json::parse(request.body())); // RS: FIXME parse errors
     auto res = response.send(Http::Code::Accepted, "Command received\n");
   }
 }
+
+void RestEndpoint::handleResponseCommand() 
+{
+  //std::cout << "Attempt to send command content: " << content << '\n';
+  std::string content("");
+  auto response = http_client_->post("localhost").body(content).send();
+  response.then(
+    [&](Http::Response response) {
+      //++completed_requests_;
+      //std::cout << "Response code = " << response.code() << std::endl;
+      auto body = response.body();
+      //if (!body.empty())
+        //std::cout << "Response body = " << body << std::endl;
+    },
+    [&](std::exception_ptr /*exc*/) {
+      // handle response failure
+      //++failed_requests_;
+      //PrintException excPrinter;
+      //excPrinter(exc);
+    }
+  );
+  //responses_.push_back(std::move(response));
+}
+

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -82,13 +82,6 @@ void RestEndpoint::handleRouteCommand(const Rest::Request& request, Http::Respon
   if ( ct->mime() != accepted_mime_ ) {
     auto res = response.send(Http::Code::Not_Acceptable, "Not a JSON command!\n");
   } else {
-    // std::ostringstream hdrsstr;
-    // for (const auto&[hk, rh] : headers.rawList()) {
-    //   hdrsstr << hk << ": " << rh.value() << '\n';
-    // }
-    // std::cout << "From: "<< addr.host() << '\n';
-    // std::cout << hdrsstr.str() << '\n';
-
     auto ansport = headers.getRaw("X-Answer-Port"); // RS: FIXME reply using headers
     cmdmeta_t meta;
     meta["answer-port"] = ansport.value();
@@ -101,15 +94,13 @@ void RestEndpoint::handleRouteCommand(const Rest::Request& request, Http::Respon
 void RestEndpoint::handleResponseCommand(const cmdobj_t& cmd, cmdmeta_t& meta) 
 {
   std::ostringstream addrstr;
-  addrstr << meta["answer-host"].get<std::string>() << ":" << meta["answer-port"].get<std::string>();
+  addrstr << meta["answer-host"].get<std::string>() << ":" << meta["answer-port"].get<std::string>() << "/response";
   meta["command"] = cmd;
+  ERS_INFO("Sending POST request to " << addrstr.str());
   auto response = http_client_->post(addrstr.str()).body(meta.dump()).send();
   response.then(
     [&](Http::Response response) {
       ERS_INFO("Response code = " << response.code());
-      // auto body = response.body();
-      // if (!body.empty())
-        // std::cout << "Response body = " << body << std::endl;
     },
     [&](std::exception_ptr exc) {
       // handle response failure

--- a/test/apps/test_rest_app.cxx
+++ b/test/apps/test_rest_app.cxx
@@ -60,7 +60,7 @@ main(int /*argc*/, char** /*argv[]*/)
   fac = createFacility(std::string("rest://localhost:12345"));
 
   // Add commanded object to facility
-  fac->set_commanded(obj);
+  fac->setCommanded(obj);
 
   // Run until marked
   fac->run(marker);

--- a/test/apps/test_rest_app.cxx
+++ b/test/apps/test_rest_app.cxx
@@ -60,7 +60,7 @@ main(int /*argc*/, char** /*argv[]*/)
   fac = createFacility(std::string("rest://localhost:12345"));
 
   // Add commanded object to facility
-  fac->setCommanded(obj);
+  fac->set_commanded(obj);
 
   // Run until marked
   fac->run(marker);


### PR DESCRIPTION
Implement completionCallback using meta information passed from the request route.
Extend send-restcmd script to expose a POST route on "answer-port", to receive response.