### PR TITLE
use CommandReply object instead of json

### DIFF
--- a/include/RestEndpoint.hpp
+++ b/include/RestEndpoint.hpp
@@ -21,6 +21,8 @@
 #include <pistache/client.h>
 #include <pistache/mime.h>
 
+#include "cmdlib/cmd/Nljs.hpp"
+
 #include <thread>
 #include <chrono>
 #include <future>
@@ -31,12 +33,11 @@ namespace dunedaq {
 namespace restcmd {
 
 typedef nlohmann::json cmdobj_t;
-typedef nlohmann::json cmdmeta_t;
 
 class RestEndpoint {
 public: 
   explicit RestEndpoint(const std::string& /*uri*/, int port,
-                        std::function<void(const cmdobj_t&, cmdmeta_t)> callback) noexcept 
+                        std::function<void(const cmdobj_t&, cmdlib::cmd::CommandReply)> callback) noexcept 
     : port_{ static_cast<uint16_t>(port) }
     , address_{ Pistache::Ipv4::any(), port_ }
     , http_endpoint_{ std::make_shared<Pistache::Http::Endpoint>( address_ ) }
@@ -52,7 +53,7 @@ public:
   void shutdown();
 
   // Client handler
-  void handleResponseCommand(const cmdobj_t& cmd, cmdmeta_t& meta);
+  void handleResponseCommand(const cmdobj_t& cmd, cmdlib::cmd::CommandReply& meta);
   
 private:
   void createRouting();
@@ -77,7 +78,7 @@ private:
   std::vector<Pistache::Async::Promise<Pistache::Http::Response>> http_client_responses_;
 
   // Function to call with received POST bodies
-  std::function<void(const cmdobj_t&, cmdmeta_t)> command_callback_;
+  std::function<void(const cmdobj_t&, cmdlib::cmd::CommandReply)> command_callback_;
 
   // Background server thread
   std::thread server_thread_;

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -94,7 +94,7 @@ protected:
     typedef CommandFacility inherited;
     
     // Implementation of completionHandler interface
-    void completion_callback(const cmdobj_t& cmd, cmdmeta_t& meta) {
+    void completion_callback(const cmdobj_t& cmd, cmd::CommandReply& meta) {
       rest_endpoint_->handleResponseCommand(cmd, meta);
     }
 
@@ -102,7 +102,7 @@ private:
     // Manager, HTTP REST Endpoint and backend resources
     mutable std::unique_ptr<RestEndpoint> rest_endpoint_;
 
-    typedef std::function<void(const cmdobj_t&, cmdmeta_t)> RequestCallback;
+    typedef std::function<void(const cmdobj_t&, cmd::CommandReply)> RequestCallback;
     RequestCallback command_executor_;
 
 };


### PR DESCRIPTION
Optional feature, avoiding (de)serializations from/to CommandReply from/to json.
Needs https://github.com/DUNE-DAQ/cmdlib/pull/15