### PR TITLE
add script with queuing of replies from flask server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(restcmd VERSION 1.0.3)
+project(restcmd VERSION 1.1.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ The URI is parsed, and the facility will listen to POST requests on the specifie
 ### <a name="sendcmd"></a> With send-restcmd
 The scripts directory also contains a command sender application based on Python3 and its Requests module. It is used on the following way:
 
-    send-restcmd.py --file ./sourcecode/restcmd/test/test-init.json
+    send-recv-restcmd.py --file ./sourcecode/restcmd/test/test-init.json
 
 The script can recognize multiple command objects in the same file, and send them one by one, with a configurable wait time between each send:
 
-    send-restcmd.py --wait 3 --file ./sourcecode/restcmd/test/fdpc-commands.json
+    send-recv-restcmd.py --wait 3 --file ./sourcecode/restcmd/test/fdpc-commands.json
 
 There is also an interactive mode. This requires typing the next command's ID from the set of commands that are available in the file:
 
-    send-restcmd.py --interactive --file ./sourcecode/restcmd/test/fdpc-commands.json
+    send-recv-restcmd.py --interactive --file ./sourcecode/restcmd/test/fdpc-commands.json
 
 To see details how to connect to different applications, have a look on the help:
 
-    send-restcmd.py --help
+    send-recv-restcmd.py --help
 
 ### <a name="sendcurl"></a> With CURL
 Sending commands with `curl` makes low-level debugging easier.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,3 +21,9 @@ There is also an interactive mode. This requires typing the next command's ID fr
     recv-restcmd.py
 
 starts a Flask server exposing a POST `/response` route on a configurable port (default 12333).
+
+## Sending and receiving command replies
+
+    send-recv-restcmd.py
+
+The best of both scripts with a fancy "command reply queue".

--- a/scripts/recv-restcmd.py
+++ b/scripts/recv-restcmd.py
@@ -2,7 +2,6 @@
 
 import argparse
 from flask import Flask, request
-from multiprocessing import Process
 
 parser = argparse.ArgumentParser(description='')
 parser.add_argument('-a', '--answer-port', type=int, default=12333, help='listening port for command return')

--- a/scripts/send-recv-restcmd.py
+++ b/scripts/send-recv-restcmd.py
@@ -9,6 +9,10 @@ import sys
 from flask import Flask, request, cli
 from multiprocessing import Process, SimpleQueue
 
+OKGREEN = '\033[92m'
+FAIL = '\033[91m'
+ENDC = '\033[0m'
+
 cli.show_server_banner = lambda *_: None
 
 parser = argparse.ArgumentParser(description='POST command object from file to commanded endpoint.')
@@ -69,8 +73,11 @@ elif isinstance(cmdstr, list):
         r = reply_queue.get()
         print("Reply:")
         print("Command: ", r["data"]["cmdid"])
-        print("Success:", r["success"])
-        print("Result:", r["result"])
+        if r["success"]:
+          print(f"{OKGREEN}", end='')
+        else:
+          print(f"{FAIL}", end='')
+        print("Result:", r["result"], f"{ENDC}")
         time.sleep(args.wait)
       except:
         print('Failed to send due to: %s' % sys.exc_info()[0])
@@ -94,8 +101,11 @@ elif isinstance(cmdstr, list):
             r = reply_queue.get()
             print("Reply:")
             print("Command: ", r["data"]["cmdid"])
-            print("Success:", r["success"])
-            print("Result:", r["result"])
+            if r["success"]:
+              print(f"{OKGREEN}", end='')
+            else:
+              print(f"{FAIL}", end='')
+            print("Result:", r["result"], f"{ENDC}")
           except:
             print('Failed to send due to: %s' % sys.exc_info()[0])
       except KeyboardInterrupt as ki:

--- a/scripts/send-recv-restcmd.py
+++ b/scripts/send-recv-restcmd.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import argparse
+import requests
+import json
+import time
+import sys
+
+from flask import Flask, request
+from multiprocessing import Process, SimpleQueue
+
+parser = argparse.ArgumentParser(description='POST command object from file to commanded endpoint.')
+parser.add_argument('--host', type=str, default='localhost', help='target host/endpoint')
+parser.add_argument('-p', '--port', type=int, default=12345, help='target port')
+parser.add_argument('-a', '--answer-port', type=int, default=12333, help='answer to service listening on this port')
+parser.add_argument('-r', '--route', type=str, default='command', help='target route on endpoint')
+parser.add_argument('-f', '--file', type=str, required=True, help='file that contains command to be posted') # This should be an argument
+parser.add_argument('-w', '--wait', type=int, default=2, help='seconds to wait between sending commands')
+parser.add_argument('-i', '--interactive', dest='interactive', action='store_true', help='interactive mode')
+parser.add_argument('--non-interactive', dest='interactive', action='store_false')
+parser.set_defaults(interactive=False)
+
+args = parser.parse_args()
+
+reply_queue = SimpleQueue()
+
+app = Flask(__name__)
+
+@app.route('/response', methods = ['POST'])
+def index():
+  json = request.get_json(force=True)
+  reply_queue.put(json)
+  return 'Response received'
+
+if __name__ == "__main__":
+  flask_server = Process(target=app.run, kwargs={'port': args.answer_port})
+  flask_server.start()
+
+url = 'http://'+args.host+':'+str(args.port)+'/'+args.route
+print('Target url: ' + url)
+headers = {'content-type': 'application/json', 'X-Answer-Port': str(args.answer_port)}
+
+cmdstr = None
+try:
+  with open(args.file) as f:
+    cmdstr = json.load(f)
+except:
+  print(f"\nERROR: failed to open file '{str(args.file)}'.")
+  raise SystemExit(0)
+
+if isinstance(cmdstr, dict):
+  print('This is single command.')
+  try:
+    response = requests.post(url, data=json.dumps(cmdstr), headers=headers)
+    print('Response code: %s with content: %s' % (str(response), str(response.content)))
+  except:
+    print('Failed to send due to: %s' % sys.exc_info()[0])
+elif isinstance(cmdstr, list):
+  print('This is a list of commands.')
+  avacmds = [cdict['id'] for cdict in cmdstr if cdict["id"]]
+  if not args.interactive:
+    for cmd in cmdstr:
+      try:
+        response = requests.post(url, data=json.dumps(cmd), headers=headers)
+        print('Response code: %s with content: %s' % (str(response), str(response.content)))
+        time.sleep(args.wait)
+      except:
+        print('Failed to send due to: %s' % sys.exc_info()[0])
+      # get response from queue
+      r = reply_queue.get()
+      print("Reply:")
+      print("Command: ", r["data"]["cmdid"])
+      print("Success:", r["success"])
+      print("Result:", r["result"])
+  else:
+    print('Interactive mode. Type the ID of the next command to send, or type \'end\' to finish.')
+    while True:
+      try:
+        print('\nAvailable commands: %s' % avacmds)
+        nextcmd = input('Press enter a command to send next: ')
+        if nextcmd == "end":
+          break
+        cmdobj = [cdict for cdict in cmdstr if cdict["id"] == nextcmd]
+        if not cmdobj:
+          print('Unrecognized command %s. (Not present in the command list?)' % nextcmd)
+        else:
+          print('Sending %s command.' % nextcmd)
+          try: 
+            response = requests.post(url, data=json.dumps(cmdobj[0]), headers=headers)
+            print('Response code: %s with content: %s' % (str(response), str(response.content))) 
+          except:
+            print('Failed to send due to: %s' % sys.exc_info()[0])
+          # get response from queue
+          r = reply_queue.get()
+          print("Reply:")
+          print("Command: ", r["data"]["cmdid"])
+          print("Success:", r["success"])
+          print("Result:", r["result"])
+      except KeyboardInterrupt as ki:
+        break
+      except EOFError as e:
+        break
+
+print('Exiting...')
+flask_server.terminate()
+flask_server.join()

--- a/scripts/send-recv-restcmd.py
+++ b/scripts/send-recv-restcmd.py
@@ -22,13 +22,14 @@ parser.set_defaults(interactive=False)
 
 args = parser.parse_args()
 
-reply_queue = SimpleQueue()
+reply_queue = SimpleQueue() # command reply queue
 
 app = Flask(__name__)
 
 @app.route('/response', methods = ['POST'])
 def index():
   json = request.get_json(force=True)
+  # enqueue command reply
   reply_queue.put(json)
   return 'Response received'
 
@@ -66,7 +67,7 @@ elif isinstance(cmdstr, list):
         time.sleep(args.wait)
       except:
         print('Failed to send due to: %s' % sys.exc_info()[0])
-      # get response from queue
+      # get command reply from queue
       r = reply_queue.get()
       print("Reply:")
       print("Command: ", r["data"]["cmdid"])
@@ -90,7 +91,7 @@ elif isinstance(cmdstr, list):
             print('Response code: %s with content: %s' % (str(response), str(response.content))) 
           except:
             print('Failed to send due to: %s' % sys.exc_info()[0])
-          # get response from queue
+          # get command reply from queue
           r = reply_queue.get()
           print("Reply:")
           print("Command: ", r["data"]["cmdid"])

--- a/scripts/send-recv-restcmd.py
+++ b/scripts/send-recv-restcmd.py
@@ -64,15 +64,15 @@ elif isinstance(cmdstr, list):
       try:
         response = requests.post(url, data=json.dumps(cmd), headers=headers)
         print('Response code: %s with content: %s' % (str(response), str(response.content)))
+        # get command reply from queue
+        r = reply_queue.get()
+        print("Reply:")
+        print("Command: ", r["data"]["cmdid"])
+        print("Success:", r["success"])
+        print("Result:", r["result"])
         time.sleep(args.wait)
       except:
         print('Failed to send due to: %s' % sys.exc_info()[0])
-      # get command reply from queue
-      r = reply_queue.get()
-      print("Reply:")
-      print("Command: ", r["data"]["cmdid"])
-      print("Success:", r["success"])
-      print("Result:", r["result"])
   else:
     print('Interactive mode. Type the ID of the next command to send, or type \'end\' to finish.')
     while True:
@@ -89,14 +89,14 @@ elif isinstance(cmdstr, list):
           try: 
             response = requests.post(url, data=json.dumps(cmdobj[0]), headers=headers)
             print('Response code: %s with content: %s' % (str(response), str(response.content))) 
+            # get command reply from queue
+            r = reply_queue.get()
+            print("Reply:")
+            print("Command: ", r["data"]["cmdid"])
+            print("Success:", r["success"])
+            print("Result:", r["result"])
           except:
             print('Failed to send due to: %s' % sys.exc_info()[0])
-          # get command reply from queue
-          r = reply_queue.get()
-          print("Reply:")
-          print("Command: ", r["data"]["cmdid"])
-          print("Success:", r["success"])
-          print("Result:", r["result"])
       except KeyboardInterrupt as ki:
         break
       except EOFError as e:

--- a/scripts/send-recv-restcmd.py
+++ b/scripts/send-recv-restcmd.py
@@ -6,8 +6,10 @@ import json
 import time
 import sys
 
-from flask import Flask, request
+from flask import Flask, request, cli
 from multiprocessing import Process, SimpleQueue
+
+cli.show_server_banner = lambda *_: None
 
 parser = argparse.ArgumentParser(description='POST command object from file to commanded endpoint.')
 parser.add_argument('--host', type=str, default='localhost', help='target host/endpoint')
@@ -25,7 +27,6 @@ args = parser.parse_args()
 reply_queue = SimpleQueue() # command reply queue
 
 app = Flask(__name__)
-
 @app.route('/response', methods = ['POST'])
 def index():
   json = request.get_json(force=True)


### PR DESCRIPTION
The command loop existing in send-restcmd now waits to poll replies from a `multiprocess.SimpleQueue`, fed by the Flask server with replies from commands.

Doesn't handle "sorting" of commands, in case of many mixed commands, but will work for the scope of this script.
Tested with automatic and interactive modes.