### PR TITLE
Converted the std::cout call in RestEndpoint::handleResponseCommand()…

### DIFF
--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -112,7 +112,7 @@ void RestEndpoint::handleResponseCommand(const cmdobj_t& cmd, dunedaq::cmdlib::c
         std::rethrow_exception(exc);
       }
       catch (const std::exception &e) {
-        std::cout << "Exception " << e.what() << '\n';
+        TLOG() << "Exception thrown by Http::Client::post() call: \"" << e.what() << "\"; errno = " << errno;
       }
     }
   );


### PR DESCRIPTION
… to use TLOG instead.

During debugging a problem sending the response back to nanorc, I found the existing message rather terse.  So, I converted the message to a TLOG and added some descriptive words.  
I'm submitting this PR because I think that it would be useful to have the extra information from the message during any future debugging.
