### PR TITLE
Application connectivity server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,9 @@ find_package(cmdlib REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(Pistache REQUIRED)
 find_package(ers REQUIRED)
+find_package(iomanager REQUIRED)
 
-set(RESTCMD_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging cmdlib::cmdlib nlohmann_json::nlohmann_json pistache_shared)
+set(RESTCMD_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers utilities::utilities logging::logging cmdlib::cmdlib iomanager::iomanager nlohmann_json::nlohmann_json pistache_shared)
 
 ##############################################################################
 # Main library

--- a/config/restcmd/control-services.data.xml
+++ b/config/restcmd/control-services.data.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="" oks-format="data" oks-version="862f2957270" created-by="plasorak" created-on="" creation-time="20231207T105549" last-modified-by="plasorak" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T092524"/>
+
+<include>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
+</include>
+
+<obj class="Service" id="drunc_controller_control">
+  <attr name="protocol" val="grpc"/>
+  <attr name="port" val="0"/>
+</obj>
+
+<obj class="Service" id="daq_application_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="0"/>
+</obj>
+
+</oks-data>

--- a/include/RestEndpoint.hpp
+++ b/include/RestEndpoint.hpp
@@ -8,8 +8,8 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#ifndef RESTCMD_SRC_RESTENDPOINT_HPP_ 
-#define RESTCMD_SRC_RESTENDPOINT_HPP_ 
+#ifndef RESTCMD_SRC_RESTENDPOINT_HPP_
+#define RESTCMD_SRC_RESTENDPOINT_HPP_
 
 #include <nlohmann/json.hpp>
 
@@ -35,9 +35,9 @@ namespace restcmd {
 typedef nlohmann::json cmdobj_t;
 
 class RestEndpoint {
-public: 
+public:
   explicit RestEndpoint(const std::string& /*uri*/, int port,
-                        std::function<void(const cmdobj_t&, cmdlib::cmd::CommandReply)> callback) noexcept 
+                        std::function<void(const cmdobj_t&, cmdlib::cmd::CommandReply)> callback) noexcept
     : port_{ static_cast<uint16_t>(port) }
     , address_{ Pistache::Ipv4::any(), port_ }
     , http_endpoint_{ std::make_shared<Pistache::Http::Endpoint>( address_ ) }
@@ -54,11 +54,16 @@ public:
 
   // Client handler
   void handleResponseCommand(const cmdobj_t& cmd, cmdlib::cmd::CommandReply& meta);
-  
+  uint16_t getPort() const {
+    return static_cast<uint16_t>(port_);
+  }
+  std::shared_ptr<Pistache::Http::Client> getHttpClient() const {
+    return http_client_;
+  }
 private:
   void createRouting();
   void createDescription();
-  void serveTask(); 
+  //void serveTask();
 
   // Route handler
   void handle_route_command(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
@@ -88,4 +93,4 @@ private:
 } // namespace restcmd
 } // namespace dunedaq
 
-#endif // RESTCMD_SRC_RESTENDPOINT_HPP_ 
+#endif // RESTCMD_SRC_RESTENDPOINT_HPP_

--- a/include/restcmd/Issues.hpp
+++ b/include/restcmd/Issues.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file Issues.hpp restcmd specific ERS Issues
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef RESTCMD_INCLUDE_RESTCMD_ISSUES_HPP_
+#define RESTCMD_INCLUDE_RESTCMD_ISSUES_HPP_
+
+
+#include "ers/Issue.hpp"
+#include <string>
+
+namespace dunedaq {
+
+/**
+ * @brief restcmd specific issues
+ * */
+
+  ERS_DECLARE_ISSUE(restcmd, EnvVarNotFound,
+                    "The environment variable wasn't set " << env_var,
+                    ((std::string)env_var))
+
+}
+
+#endif // RESTCMD_INCLUDE_RESTCMD_ISSUES_HPP_

--- a/include/restcmd/RestEndpoint.hpp
+++ b/include/restcmd/RestEndpoint.hpp
@@ -23,6 +23,8 @@
 
 #include "cmdlib/cmd/Nljs.hpp"
 
+#include "restcmd/Issues.hpp"
+
 #include <thread>
 #include <chrono>
 #include <future>

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -91,7 +91,7 @@ public:
         m_connectivity_client = std::make_unique<dunedaq::iomanager::ConfigClient>(
           m_connectivity_server,
           m_connectivity_port,
-          std::chrono::milliseconds(2_000) // pulling the configuration to get this number here seems a bit overkill
+          std::chrono::milliseconds(2000) // pulling the configuration to get this number here seems a bit overkill
         );
       }
 

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -151,7 +151,7 @@ public:
       if (m_connectivity_client) {
         dunedaq::iomanager::connection::ConnectionId ci{
           m_name + "_control",
-          "json-control-messages",
+          "RunControlMessage",
           m_session
         };
         m_connectivity_client->retract(ci);

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -86,7 +86,7 @@ public:
         char* port_char    = std::getenv("CONNECTION_PORT");
 
         if (!server_chars || !port_char)
-          throw dunedaq::cmdlib::MissingEnvVar(ERS_HERE, "CONNECTION_SERVER or CONNECTION_PORT");
+          throw dunedaq::restcmd::EnvVarNotFound(ERS_HERE, "CONNECTION_SERVER or CONNECTION_PORT");
 
         m_connectivity_server = std::string(server_chars);
         m_connectivity_port   = std::string(port_char);

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -115,6 +115,12 @@ public:
     }
 
     void run(std::atomic<bool>& end_marker) {
+
+      char* app_name_c = std::getenv("DUNEDAQ_APPLICATION_NAME");
+      if (!app_name_c)
+        throw dunedaq::restcmd::EnvVarNotFound(ERS_HERE, "DUNEDAQ_APPLICATION_NAME");
+      std::string app_name =  std::string(app_name_c);
+
       // Start endpoint
       try {
         rest_endpoint_->start();
@@ -129,9 +135,9 @@ public:
           if (ips.size() == 0)
             throw dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, "Could not resolve hostname to IP address");
 
-          TLOG() << "Registering the control endpoint (" << m_name << "_control) on the connectivity service: " << ips[0] << ":" << port;
+          TLOG() << "Registering the control endpoint (" << app_name << "_control) on the connectivity service: " << ips[0] << ":" << port;
           dunedaq::iomanager::ConnectionRegistration cr;
-          cr.uid =  m_name + "_control";
+          cr.uid =  app_name + "_control";
           cr.data_type = "RunControlMessage";
           cr.uri = "rest://" + ips[0] + ":" + std::to_string(port);
           cr.connection_type = dunedaq::iomanager::connection::ConnectionType::kSendRecv;
@@ -151,7 +157,7 @@ public:
       rest_endpoint_->shutdown();
       if (m_connectivity_client) {
         dunedaq::iomanager::connection::ConnectionId ci{
-          m_name + "_control",
+          app_name + "_control",
           "RunControlMessage",
           m_session
         };

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -13,12 +13,17 @@
 #include <logging/Logging.hpp>
 #include <cetlib/BasicPluginFactory.h>
 #include <tbb/concurrent_queue.h>
+#include <pistache/client.h>
+#include <pistache/http.h>
 
 #include <fstream>
 #include <string>
 #include <memory>
 #include <chrono>
 #include <functional>
+#include <unistd.h>
+#include <limits.h>
+#include <map>
 
 using namespace dunedaq::cmdlib;
 using namespace dunedaq::restcmd;
@@ -50,25 +55,31 @@ public:
       std::string epname = uri.substr(sep+3, at-(sep+3));
       std::string hostname = uri.substr(at+1, col-(at+1));
 
-      int port = -1; 
+      int port = -1;
       try { // to parse port
         port = std::stoi(portstr);
         if (!(0 <= port && port <= 65535)) { // valid port
-          throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Invalid port ", portstr); 
+          throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Invalid port ", portstr);
         }
       }
       catch (const std::exception& ex) {
         throw dunedaq::cmdlib::MalformedUri(ERS_HERE, ex.what(), portstr);
       }
 
+      app_discovery_service_ = std::getenv("APP_DISCOVERY_SERVICE");
+      if (port == 0 && !app_discovery_service_) {
+        throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Can't bind to port 0 without app discovery service", portstr);
+      }
+
       try { // to setup backend
         command_executor_ = std::bind(&inherited::execute_command, this, std::placeholders::_1, std::placeholders::_2);
         rest_endpoint_= std::make_unique<dunedaq::restcmd::RestEndpoint>(hostname, port, command_executor_);
         rest_endpoint_->init(1); // 1 thread
-        TLOG() <<"Endpoint open on: " << epname << " host:" << hostname << " port:" << portstr;
-      } 
+        TLOG() <<"Endpoint open on: " << epname << " host:" << hostname << " port:" << port;
+
+      }
       catch (const std::exception& ex) {
-         ers::error(dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, ex.what())); 
+         ers::error(dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, ex.what()));
       }
     }
 
@@ -76,7 +87,40 @@ public:
       // Start endpoint
       try {
         rest_endpoint_->start();
-      } 
+        int port = rest_endpoint_->getPort();
+        if (app_discovery_service_) {
+            std::ostringstream addrstr;
+            addrstr << app_discovery_service_ << "/app-registry/v0.0.0/app-control-connection";
+            nlohmann::json body_json;
+            std::string session = std::getenv("DUNEDAQ_SESSION");
+
+            char hostname[HOST_NAME_MAX];
+            gethostname(hostname, HOST_NAME_MAX);
+            std::map<std::string,std::string> endpoint_description = {
+                {"name", m_name},
+                {"endpoint", "rest://"+std::string(hostname)+":"+std::to_string(port)}
+            };
+            body_json["session"] = session;
+            body_json["endpoints"] = std::vector<std::map<std::string,std::string>>();
+            body_json["endpoints"].push_back(endpoint_description);
+
+            auto response = rest_endpoint_->getHttpClient()->post(addrstr.str()).body(body_json.dump()).send();
+            response.then(
+              [&](Pistache::Http::Response response) {
+                TLOG() << "Response code = " << response.code();
+              },
+              [&](std::exception_ptr exc) {
+                // handle response failure
+                try{
+                  std::rethrow_exception(exc);
+                }
+                catch (const std::exception &e) {
+                  TLOG() << "Exception thrown by Http::Client::post() call: \"" << e.what() << "\"; errno = " << errno;
+                }
+              }
+           );
+        }
+      }
       catch (const std::exception& ex) {
         ers::fatal(dunedaq::cmdlib::RunLoopTerminated(ERS_HERE, ex.what()));
       }
@@ -88,11 +132,39 @@ public:
 
       // Shutdown
       rest_endpoint_->shutdown();
+      if (app_discovery_service_) {
+        std::ostringstream addrstr;
+        addrstr << app_discovery_service_ << "/app-registry/v0.0.0/app-control-connection";
+        nlohmann::json body_json;
+        std::string session = std::getenv("DUNEDAQ_SESSION");
+
+        char hostname[HOST_NAME_MAX];
+        gethostname(hostname, HOST_NAME_MAX);
+        body_json["session"] = session;
+        body_json["name"] = m_name;
+
+        auto response = rest_endpoint_->getHttpClient()->del(addrstr.str()).body(body_json.dump()).send();
+        response.then(
+          [&](Pistache::Http::Response response) {
+            TLOG() << "Response code = " << response.code();
+          },
+          [&](std::exception_ptr exc) {
+            // handle response failure
+            try{
+              std::rethrow_exception(exc);
+            }
+            catch (const std::exception &e) {
+              TLOG() << "Exception thrown by Http::Client::delete() call: \"" << e.what() << "\"; errno = " << errno;
+            }
+          }
+        );
+      }
+
     }
 
 protected:
     typedef CommandFacility inherited;
-    
+
     // Implementation of completionHandler interface
     void completion_callback(const cmdobj_t& cmd, cmd::CommandReply& meta) {
       rest_endpoint_->handleResponseCommand(cmd, meta);
@@ -104,11 +176,12 @@ private:
 
     typedef std::function<void(const cmdobj_t&, cmd::CommandReply)> RequestCallback;
     RequestCallback command_executor_;
-
+    const char* app_discovery_service_ = nullptr;
+    std::string app_name_;
 };
 
 extern "C" {
-    std::shared_ptr<dunedaq::cmdlib::CommandFacility> make(std::string uri) { 
+    std::shared_ptr<dunedaq::cmdlib::CommandFacility> make(std::string uri) {
         return std::shared_ptr<dunedaq::cmdlib::CommandFacility>(new restCommandFacility(uri));
     }
 }

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -181,7 +181,15 @@ private:
 };
 
 extern "C" {
-    std::shared_ptr<dunedaq::cmdlib::CommandFacility> make(std::string uri) {
-        return std::shared_ptr<dunedaq::cmdlib::CommandFacility>(new restCommandFacility(uri));
-    }
+  std::shared_ptr<dunedaq::cmdlib::CommandFacility> make(
+    std::string uri,
+    int connectivity_service_interval_ms,
+    bool use_connectivity_service) {
+
+    return std::shared_ptr<dunedaq::cmdlib::CommandFacility>(new restCommandFacility(
+      uri,
+      connectivity_service_interval_ms,
+      use_connectivity_service)
+    );
+  }
 }

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -129,6 +129,7 @@ public:
           if (ips.size() == 0)
             throw dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, "Could not resolve hostname to IP address");
 
+          TLOG() << "Registering the control endpoint (" << m_name << "_control) on the connectivity service: " << ips[0] << ":" << port;
           dunedaq::iomanager::ConnectionRegistration cr;
           cr.uid =  m_name + "_control";
           cr.data_type = "RunControlMessage";

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -129,7 +129,7 @@ public:
           dunedaq::iomanager::ConnectionRegistration cr;
           cr.uid =  m_name + "_control";
           cr.data_type = "json-control-messages";
-          cr.uri = "rest" + ips[0] + ":" + std::to_string(port);
+          cr.uri = "rest://" + ips[0] + ":" + std::to_string(port);
           cr.connection_type = dunedaq::iomanager::connection::ConnectionType::kSendRecv;
           // unclear why I can't do the following
           // dunedaq::iomanager::ConnectionRegistration cr = {

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -22,7 +22,7 @@ void RestEndpoint::init(size_t threads)
   auto opts = Http::Endpoint::options()
     .threads(static_cast<int>(threads))
     .maxRequestSize(15728640) // 15MB
-    .maxResponseSize(1048576) // 1MB 
+    .maxResponseSize(1048576) // 1MB
     .flags(Pistache::Tcp::Options::ReuseAddr)
     .flags(Pistache::Tcp::Options::ReusePort);
 
@@ -32,21 +32,22 @@ void RestEndpoint::init(size_t threads)
   http_client_->init(http_client_options_);
 }
 
-void RestEndpoint::start() 
+void RestEndpoint::start()
 {
-  server_thread_ = std::thread(&RestEndpoint::serveTask, this);
+  http_endpoint_->setHandler(router_.handler());
+  http_endpoint_->serveThreaded();
+  port_ = http_endpoint_->getPort();
+  TLOG() << "REST server started on port " << port_;
 }
 
-void RestEndpoint::serveTask() 
-{     
-  http_endpoint_->setHandler(router_.handler());
-  http_endpoint_->serve();
-}
+// void RestEndpoint::serveTask()
+// {
+// }
 
 void RestEndpoint::shutdown()
 {
   http_endpoint_->shutdown();
-  server_thread_.join();
+  //server_thread_.join();
   http_client_->shutdown();
 }
 
@@ -56,15 +57,15 @@ void RestEndpoint::createRouting()
   Routes::Post(router_, "/command", Routes::bind(&RestEndpoint::handle_route_command, this));
 }
 
-inline void extendHeader(Http::Header::Collection& headers) 
+inline void extendHeader(Http::Header::Collection& headers)
 {
   headers.add<Http::Header::AccessControlAllowOrigin>("*");
   headers.add<Http::Header::AccessControlAllowMethods>("POST,GET");
   headers.add<Http::Header::ContentType>(MIME(Text, Plain));
 }
 
-inline 
-std::string 
+inline
+std::string
 getClientAddress(const Pistache::Rest::Request &request) {
   const auto xff = request.headers().tryGetRaw("X-Forwarded-For");
   if (!xff.isEmpty()) {
@@ -79,7 +80,7 @@ void RestEndpoint::handle_route_command(const Rest::Request& request, Http::Resp
   dunedaq::cmdlib::cmd::CommandReply meta;
   auto addr = request.address();
   auto headers = request.headers();
-  auto ct = headers.get<Http::Header::ContentType>(); 
+  auto ct = headers.get<Http::Header::ContentType>();
   if ( ct->mime() != accepted_mime_ ) {
     auto res = response.send(Http::Code::Not_Acceptable, "Not a JSON command!\n");
   } else {
@@ -92,7 +93,7 @@ void RestEndpoint::handle_route_command(const Rest::Request& request, Http::Resp
   }
 }
 
-void RestEndpoint::handleResponseCommand(const cmdobj_t& cmd, dunedaq::cmdlib::cmd::CommandReply& meta) 
+void RestEndpoint::handleResponseCommand(const cmdobj_t& cmd, dunedaq::cmdlib::cmd::CommandReply& meta)
 {
   dunedaq::cmdlib::cmd::Command command = cmd.get<dunedaq::cmdlib::cmd::Command>();
   std::ostringstream addrstr;

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -5,7 +5,7 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#include "RestEndpoint.hpp"
+#include "restcmd/RestEndpoint.hpp"
 
 #include <logging/Logging.hpp>
 


### PR DESCRIPTION
Initial implementation of a application connectivity server.
Basically what this code does is
 - Check that the `APP_DISCOVERY_SERVICE` env var is set, if it is, advertise the (dynamically) alocated port of the application to it.
 - If `APP_DISCOVERY_SERVICE` is not set, and the port number is 0 (i.e. we want the kernel to assign the port), it crashes.
 - When the server shuts down, deregister the application.

There is still duplicated ugly code in this, which is why it's in draft.

Requires: https://github.com/DUNE-DAQ/cmdlib/pull/25