### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/restcmd/Issues.hpp
+++ b/include/restcmd/Issues.hpp
@@ -10,6 +10,7 @@
 
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <string>
 
 namespace dunedaq {

--- a/include/restcmd/Issues.hpp
+++ b/include/restcmd/Issues.hpp
@@ -10,7 +10,7 @@
 
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <string>
 
 namespace dunedaq {

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -17,7 +17,7 @@
 #include "utilities/Resolver.hpp"
 
 #include <cetlib/BasicPluginFactory.h>
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 #include <tbb/concurrent_queue.h>
 
 #include <chrono>

--- a/src/RestEndpoint.cpp
+++ b/src/RestEndpoint.cpp
@@ -7,7 +7,7 @@
  */
 #include "restcmd/RestEndpoint.hpp"
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 #include <chrono>
 #include <future>

--- a/test/apps/rest_commanded_object.hpp
+++ b/test/apps/rest_commanded_object.hpp
@@ -12,7 +12,7 @@
 
 #include "cmdlib/CommandedObject.hpp"
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 #include <stdexcept>
 #include <string>

--- a/test/apps/test_rest_app.cxx
+++ b/test/apps/test_rest_app.cxx
@@ -12,7 +12,7 @@
 #include "cmdlib/CommandedObject.hpp"
 #include "rest_commanded_object.hpp"
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 #include <string>
 #include <chrono>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)