### PR TITLE
Using URI hostname resolution

### DIFF
--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -50,39 +50,10 @@ public:
 
     folly::Uri furi(uri);
 
-    // // Parse URI
-    // auto col = uri.find_last_of(':');
-    // auto at = uri.find('@');
-    // auto sep = uri.find("://");
-    // if (col == std::string::npos || sep == std::string::npos) { // enforce URI
-    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Malformed URI: ", uri);
-    // }
-    // // std::string scheme = uri.substr(0, sep);
-    // std::string iname = uri.substr(sep + 3);
-    // if (iname.empty()) {
-    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Missing interface name in ", uri);
-    // }
-    // std::string portstr = uri.substr(col + 1);
-    // if (portstr.empty() || portstr.find(iname) != std::string::npos) {
-    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Can't bind without port in ", uri);
-    // }
-    // std::string epname = uri.substr(sep + 3, at - (sep + 3));
-    // std::string hostname = uri.substr(at + 1, col - (at + 1));
-
-
     std::string hostname = furi.hostname();
     int port = furi.port();
 
-    std::string epname = std::format("{}:{}", hostname, port);
-    // try { // to parse port
-    //   port = std::stoi(portstr);
-    //   if (!(0 <= port && port <= 65535)) { // valid port
-    //     throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Invalid port ", portstr);
-    //   }
-    // } catch (const std::exception& ex) {
-    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, ex.what(), portstr);
-    // }
-
+    std::string epname = ;
     if (connectivity_service != nullptr) {
       auto connectivity_service_port = std::to_string(connectivity_service->get_service()->get_port());
       m_connectivity_client = std::make_unique<dunedaq::iomanager::ConfigClient>(
@@ -101,7 +72,7 @@ public:
       command_executor_ = std::bind(&inherited::execute_command, this, std::placeholders::_1, std::placeholders::_2);
       rest_endpoint_ = std::make_unique<dunedaq::restcmd::RestEndpoint>(hostname, port, command_executor_);
       rest_endpoint_->init(1); // 1 thread
-      TLOG() << "Endpoint open on: " << epname << " host:" << hostname << " port:" << port;
+      TLOG() << std::format("Endpoint open on host: {} port: {}", hostname, port);
 
     } catch (const std::exception& ex) {
       ers::error(dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, ex.what()));

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -18,7 +18,8 @@
 
 #include <cetlib/BasicPluginFactory.h>
 #include "logging/Logging.hpp"
-#include <tbb/concurrent_queue.h>
+// #include <tbb/concurrent_queue.h>
+#include <folly/Uri.h>
 
 #include <chrono>
 #include <fstream>
@@ -46,34 +47,41 @@ public:
     , m_session_name(session_name)
   {
 
-    // Parse URI
-    auto col = uri.find_last_of(':');
-    auto at = uri.find('@');
-    auto sep = uri.find("://");
-    if (col == std::string::npos || sep == std::string::npos) { // enforce URI
-      throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Malformed URI: ", uri);
-    }
-    std::string scheme = uri.substr(0, sep);
-    std::string iname = uri.substr(sep + 3);
-    if (iname.empty()) {
-      throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Missing interface name in ", uri);
-    }
-    std::string portstr = uri.substr(col + 1);
-    if (portstr.empty() || portstr.find(iname) != std::string::npos) {
-      throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Can't bind without port in ", uri);
-    }
-    std::string epname = uri.substr(sep + 3, at - (sep + 3));
-    std::string hostname = uri.substr(at + 1, col - (at + 1));
 
-    int port = -1;
-    try { // to parse port
-      port = std::stoi(portstr);
-      if (!(0 <= port && port <= 65535)) { // valid port
-        throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Invalid port ", portstr);
-      }
-    } catch (const std::exception& ex) {
-      throw dunedaq::cmdlib::MalformedUri(ERS_HERE, ex.what(), portstr);
-    }
+    folly::Uri furi(uri);
+
+    // // Parse URI
+    // auto col = uri.find_last_of(':');
+    // auto at = uri.find('@');
+    // auto sep = uri.find("://");
+    // if (col == std::string::npos || sep == std::string::npos) { // enforce URI
+    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Malformed URI: ", uri);
+    // }
+    // // std::string scheme = uri.substr(0, sep);
+    // std::string iname = uri.substr(sep + 3);
+    // if (iname.empty()) {
+    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Missing interface name in ", uri);
+    // }
+    // std::string portstr = uri.substr(col + 1);
+    // if (portstr.empty() || portstr.find(iname) != std::string::npos) {
+    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Can't bind without port in ", uri);
+    // }
+    // std::string epname = uri.substr(sep + 3, at - (sep + 3));
+    // std::string hostname = uri.substr(at + 1, col - (at + 1));
+
+
+    std::string hostname = furi.hostname();
+    int port = furi.port();
+
+    std::string epname = std::format("{}:{}", hostname, port);
+    // try { // to parse port
+    //   port = std::stoi(portstr);
+    //   if (!(0 <= port && port <= 65535)) { // valid port
+    //     throw dunedaq::cmdlib::MalformedUri(ERS_HERE, "Invalid port ", portstr);
+    //   }
+    // } catch (const std::exception& ex) {
+    //   throw dunedaq::cmdlib::MalformedUri(ERS_HERE, ex.what(), portstr);
+    // }
 
     if (connectivity_service != nullptr) {
       auto connectivity_service_port = std::to_string(connectivity_service->get_service()->get_port());
@@ -86,7 +94,7 @@ public:
 
     if (port == 0 && connectivity_service == nullptr) {
       throw dunedaq::cmdlib::MalformedUri(
-        ERS_HERE, "Can't bind the REST API to port 0 without connectivity service", portstr);
+        ERS_HERE, "Can't bind the REST API to port 0 without connectivity service", std::to_string(port));
     }
 
     try { // to setup backend
@@ -101,6 +109,7 @@ public:
 
     // Store hostname for connectivity service registration
     m_hostname = hostname;
+    TLOG() << "AAAAAA Hostname " << m_hostname;
   }
 
   void run(std::atomic<bool>& end_marker)

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -95,7 +95,7 @@ public:
       if (m_connectivity_client) {
         int port = rest_endpoint_->getPort();
 
-        auto ips = dunedaq::utilities::get_ips_from_hostname(m_hostname);
+        auto ips = dunedaq::utilities::get_hostname_ips(m_hostname);
 
         if (ips.size() == 0)
           throw dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, "Could not resolve hostname to IP address");

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -53,7 +53,6 @@ public:
     std::string hostname = furi.hostname();
     int port = furi.port();
 
-    std::string epname = ;
     if (connectivity_service != nullptr) {
       auto connectivity_service_port = std::to_string(connectivity_service->get_service()->get_port());
       m_connectivity_client = std::make_unique<dunedaq::iomanager::ConfigClient>(

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -80,7 +80,6 @@ public:
 
     // Store hostname for connectivity service registration
     m_hostname = hostname;
-    TLOG() << "AAAAAA Hostname " << m_hostname;
   }
 
   void run(std::atomic<bool>& end_marker)

--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -98,6 +98,9 @@ public:
     } catch (const std::exception& ex) {
       ers::error(dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, ex.what()));
     }
+
+    // Store hostname for connectivity service registration
+    m_hostname = hostname;
   }
 
   void run(std::atomic<bool>& end_marker)
@@ -115,9 +118,7 @@ public:
       if (m_connectivity_client) {
         int port = rest_endpoint_->getPort();
 
-        char hostname[HOST_NAME_MAX];
-        gethostname(hostname, HOST_NAME_MAX);
-        auto ips = dunedaq::utilities::get_ips_from_hostname(std::string(hostname));
+        auto ips = dunedaq::utilities::get_ips_from_hostname(m_hostname);
 
         if (ips.size() == 0)
           throw dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, "Could not resolve hostname to IP address");
@@ -165,6 +166,7 @@ private:
   RequestCallback command_executor_;
 
   std::string m_session_name;
+  std::string m_hostname;
   std::unique_ptr<dunedaq::iomanager::ConfigClient> m_connectivity_client;
 };
 


### PR DESCRIPTION
The restcommand endpoint allocation defaults to the system hostname to open the network endpoint.
This PR modifies the behaviour to use the hostname as specified in the uri, enabling the selction of specific network interfaces if needed.