### PR TITLE
Update for refactoring of utilities Resolver header.

### DIFF
--- a/plugins/restCommandFacility.cpp
+++ b/plugins/restCommandFacility.cpp
@@ -13,8 +13,7 @@
 #include "confmodel/ConnectivityService.hpp"
 #include "iomanager/network/ConfigClient.hpp"
 #include "iomanager/network/ConfigClientStructs.hpp"
-
-#include "utilities/Resolver.hpp"
+#include "utilities/get_ips.hpp"
 
 #include <cetlib/BasicPluginFactory.h>
 #include "logging/Logging.hpp"
@@ -117,7 +116,7 @@ public:
 
         char hostname[HOST_NAME_MAX];
         gethostname(hostname, HOST_NAME_MAX);
-        auto ips = dunedaq::utilities::get_ips_from_hostname(std::string(hostname));
+        auto ips = dunedaq::utilities::get_hostname_ips(std::string(hostname));
 
         if (ips.size() == 0)
           throw dunedaq::cmdlib::CommandFacilityInitialization(ERS_HERE, "Could not resolve hostname to IP address");


### PR DESCRIPTION
In DUNE-DAQ/utilities#57, the Resolver.hpp header was reorganized, update usage for new include file and method name.